### PR TITLE
Cosmetic cleanups and postmenu customization

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -9,3 +9,4 @@
 @import "common/home-categories";
 @import "common/footer";
 @import "common/cleanups";
+@import "common/post-menu";

--- a/common/common.scss
+++ b/common/common.scss
@@ -8,3 +8,4 @@
 @import "common/header";
 @import "common/home-categories";
 @import "common/footer";
+@import "common/cleanups";

--- a/scss/colors.scss
+++ b/scss/colors.scss
@@ -1,5 +1,6 @@
 $white: #FFF;
 $black: #000;
 $darkgreen: #136C53;
-$light_green: #c0EFc0;
 $verylightgreen: #F3FAF8;
+$lightgreen: #c0EFc0;
+

--- a/scss/common/cleanups.scss
+++ b/scss/common/cleanups.scss
@@ -4,7 +4,7 @@
     .select-kit-body{
       // masquer les filtres de tri "plus vu" et "dernier message".
       // Is it fragile ? Oh yes it is. Is there a better solution ?
-      // Not without overriding templates or plugins, and both are fragile too.
+      // Not without overriding templates or with plugins. Sadly both are fragile too.
       .select-kit-collection {
         li[data-name="Plus vu"], li[data-name="Dernier message"] {
           display: none;
@@ -14,20 +14,8 @@
   }
 }
 
-// Hide posters circles
-.topic-list {
-  td.posters, th.posters { display: none; }
-}
-
 // hide first-time/returning users
 // https://meta.discourse.org/t/post-notices-for-first-time-and-returning-users/112078
 .post-notice {
   display: none;
 }
-
-// Pour le moment, on est partagé sur la suppression de la barre de recherche. Peut-être juste sur la home ?
-// .d-header-wrap {
-//   // suppression de la zone de recherche en entête
-//
-//   .search-dropdown { display: none; }
-// }

--- a/scss/common/cleanups.scss
+++ b/scss/common/cleanups.scss
@@ -1,0 +1,33 @@
+// Hide some search filters
+.search-info{
+  .sort-by{
+    .select-kit-body{
+      // masquer les filtres de tri "plus vu" et "dernier message".
+      // Is it fragile ? Oh yes it is. Is there a better solution ?
+      // Not without overriding templates or plugins, and both are fragile too.
+      .select-kit-collection {
+        li[data-name="Plus vu"], li[data-name="Dernier message"] {
+          display: none;
+        }
+      }
+    }
+  }
+}
+
+// Hide posters circles
+.topic-list {
+  td.posters, th.posters { display: none; }
+}
+
+// hide first-time/returning users
+// https://meta.discourse.org/t/post-notices-for-first-time-and-returning-users/112078
+.post-notice {
+  display: none;
+}
+
+// Pour le moment, on est partagé sur la suppression de la barre de recherche. Peut-être juste sur la home ?
+// .d-header-wrap {
+//   // suppression de la zone de recherche en entête
+//
+//   .search-dropdown { display: none; }
+// }

--- a/scss/common/post-menu.scss
+++ b/scss/common/post-menu.scss
@@ -1,0 +1,61 @@
+@import "colors";
+
+@mixin cta-answer-button-secondary {
+  & {
+    font-size: 1em;
+    border-radius: 3px;
+    background-color: transparent;
+    color: $darkgreen;
+    text-transform: uppercase;
+  }
+  &:hover {
+    color: $white;
+    background: $darkgreen;
+  }
+}
+
+// customization of the colors for the post menu button
+// originally in app/assets/stylesheets/desktop/topic-post.scss
+// due to the way styles are applied, it is not possible to simply include the primary or secondary cta styles
+nav.post-controls {
+  .actions {
+    // The post-controls buttons mostly are secondary buttons
+    button {
+      @include cta-answer-button-secondary;
+    }
+    .btn-flat {
+      .d-button-label,
+      .d-icon {
+        color: $darkgreen;
+      }
+      background-color: transparent;
+    }
+    .btn-flat:hover {
+      color: $white;
+      background-color: $darkgreen;
+      .d-button-label,
+      .d-icon {
+        color: white;
+      }
+    }
+
+    // The reply button is a primary button, so it has a dedicated style
+    .btn-flat + .reply {
+      background-color: $darkgreen;
+      border: 1px solid $darkgreen;
+      .d-button-label,
+      .d-icon {
+        color: white;
+      }
+
+      &:hover {
+        color: $white;
+        background-color: transparent;
+        .d-button-label,
+        .d-icon {
+          color: $darkgreen;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Quelques nettoyages:
 - suppression des blocs du type "xy vient d'arriver sur la plateforme, souhaitez lui la bienvenue"
 - suppression de filtres de recherche
 - personnalisation des boutons sous un post.
   - La simplification des options d'action sous un post se fait via l'interface admin (`/admin/site_settings/category/basic` -> on sélectionne ce qu'on veut dans `post menu` et `post menu hidden items`)
   - La personnalisation graphique a lieu ici.
   - *il faut aussi re-traduire `solved.has_no_accepted_answer` pour avoir notre version*

À noter que le "post menu" est très dynamique et contraint (cf `app/assets/javascripts/discourse/app/widgets/post-menu.js`), on a pas énormément la main pour faire des trucs fous.

![Capture d’écran de 2020-12-07 15-37-36](https://user-images.githubusercontent.com/1223316/101363984-55300580-38a2-11eb-8f3f-3eddfbd1c711.png)

Note pour moi, si jamais: la structure du HTML ressemble en gros à ça:

```
nav.post-controls.actions
	div.double-button
		widget-button btn-flat button-count like-count highlight-action regular-likes btn-text
	widget-button btn-flat edit no-text btn-icon
	widget-button btn-flat delete no-text btn-icon
	span.extra-buttons
		widget-button btn-flat unaccepted btn-icon-text
	widget-button btn-flat show-post-admin-menu no-text btn-icon
	widget-button btn-flat reply create fade-out btn-icon-text
```
