### PR TITLE
Personnalisation des listes

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -10,3 +10,4 @@
 @import "common/footer";
 @import "common/cleanups";
 @import "common/post-menu";
+@import "common/categories";

--- a/common/footer.html
+++ b/common/footer.html
@@ -6,7 +6,7 @@
       </div>
 
       <div class="footer-column">
-        <p>Accédez à notre <a href="https://inclusion.beta.gouv.fr/stats/">page statistiques</a></p>
+        <p>Accédez à notre <a href="/stats/">page statistiques</a></p>
         <p>Accès <a href="https://github.com/betagouv/itou">GitHub</a> et <a href="https://github.com/betagouv/itou/blob/master/CHANGELOG.md">changelog</a></p>
         <p>
           <a href="https://doc.inclusion.beta.gouv.fr/pourquoi-une-plateforme-de-linclusion/qui-est-derriere-la-plateforme-de-linclusion">

--- a/javascripts/components/topic-list.hbs
+++ b/javascripts/components/topic-list.hbs
@@ -1,0 +1,59 @@
+{{#unless skipHeader}}
+  <thead>
+    {{raw "topic-list-header"
+      canBulkSelect=canBulkSelect
+      toggleInTitle=toggleInTitle
+      hideCategory=hideCategory
+      showPosters=showPosters
+      showLikes=showLikes
+      showOpLikes=showOpLikes
+      order=order
+      ascending=ascending
+      sortable=sortable
+      listTitle=listTitle
+      bulkSelectEnabled=bulkSelectEnabled}}
+  </thead>
+{{/unless}}
+
+{{plugin-outlet
+  name="before-topic-list-body"
+  args=(hash
+    topics=topics
+    selected=selected
+    bulkSelectEnabled=bulkSelectEnabled
+    lastVisitedTopic=lastVisitedTopic
+    discoveryList=discoveryList
+    hideCategory=hideCategory)
+  tagName=""
+  connectorTagName=""}}
+
+<tbody>
+  {{#each filteredTopics as |topic|}}
+    {{topic-list-item topic=topic
+                      bulkSelectEnabled=bulkSelectEnabled
+                      showTopicPostBadges=showTopicPostBadges
+                      hideCategory=hideCategory
+                      showPosters=showPosters
+                      hideMobileAvatar=hideMobileAvatar
+                      showLikes=showLikes
+                      showOpLikes=showOpLikes
+                      expandGloballyPinned=expandGloballyPinned
+                      expandAllPinned=expandAllPinned
+                      lastVisitedTopic=lastVisitedTopic
+                      selected=selected
+                      tagsForUser=tagsForUser}}
+    {{raw "list/visited-line" lastVisitedTopic=lastVisitedTopic topic=topic}}
+  {{/each}}
+</tbody>
+
+{{plugin-outlet
+  name="after-topic-list-body"
+  args=(hash
+    topics=topics
+    selected=selected
+    bulkSelectEnabled=bulkSelectEnabled
+    lastVisitedTopic=lastVisitedTopic
+    discoveryList=discoveryList
+    hideCategory=hideCategory)
+  tagName=""
+  connectorTagName=""}}

--- a/javascripts/list/activity-column.hbr
+++ b/javascripts/list/activity-column.hbr
@@ -1,0 +1,6 @@
+<{{tagName}} class="{{class}} {{cold-age-class topic.createdAt startDate=topic.bumpedAt class=""}} activity" title="{{html-safe topic.bumpedAtTitle}}">
+  <a class="post-activity" href="{{topic.lastPostUrl}}">
+    {{~raw-plugin-outlet name="topic-list-before-relative-date"~}}
+    {{~format-date topic.bumpedAt format="tiny" noTitle="true"~}}
+  </a>
+</{{tagName}}>

--- a/javascripts/list/activity-column.hbr
+++ b/javascripts/list/activity-column.hbr
@@ -1,6 +1,6 @@
 <{{tagName}} class="{{class}} {{cold-age-class topic.createdAt startDate=topic.bumpedAt class=""}} activity" title="{{html-safe topic.bumpedAtTitle}}">
   <a class="post-activity" href="{{topic.lastPostUrl}}">
     {{~raw-plugin-outlet name="topic-list-before-relative-date"~}}
-    {{~format-date topic.bumpedAt format="tiny" noTitle="true"~}}
+    <i class="icon-calendar"></i>&nbsp;{{~format-date topic.bumpedAt format="tiny" noTitle="true"~}}
   </a>
 </{{tagName}}>

--- a/javascripts/list/posts-count-column.hbr
+++ b/javascripts/list/posts-count-column.hbr
@@ -1,0 +1,6 @@
+<{{view.tagName}} class='num posts-map posts {{view.likesHeat}}' title='{{view.title}}'>
+  <a href class='posts-map badge-posts {{view.likesHeat}}'>
+    {{raw-plugin-outlet name="topic-list-before-reply-count"}}
+    {{number topic.replyCount noTitle="true" ariaLabel=view.title}}
+  </a>
+</{{view.tagName}}>

--- a/javascripts/list/posts-count-column.hbr
+++ b/javascripts/list/posts-count-column.hbr
@@ -1,6 +1,6 @@
 <{{view.tagName}} class='num posts-map posts {{view.likesHeat}}' title='{{view.title}}'>
   <a href class='posts-map badge-posts {{view.likesHeat}}'>
     {{raw-plugin-outlet name="topic-list-before-reply-count"}}
-    {{number topic.replyCount noTitle="true" ariaLabel=view.title}}
+    <i class="icon-talk"></i>&nbsp;{{number topic.replyCount noTitle="true" ariaLabel=view.title}}
   </a>
 </{{view.tagName}}>

--- a/javascripts/list/solved-column.hbr
+++ b/javascripts/list/solved-column.hbr
@@ -1,4 +1,4 @@
-<td>
+<td class="categories-topic-solved">
   {{#if topic.has_accepted_answer }}
     <i class="icon-done"></i>
   {{else}}

--- a/javascripts/list/solved-column.hbr
+++ b/javascripts/list/solved-column.hbr
@@ -1,0 +1,7 @@
+<td class="num ">
+  {{#if topic.has_accepted_answer }}
+    <i class="icon-done"></i>
+  {{else}}
+    &nbsp;
+  {{/if}}
+</td>

--- a/javascripts/list/solved-column.hbr
+++ b/javascripts/list/solved-column.hbr
@@ -1,4 +1,4 @@
-<td class="num ">
+<td>
   {{#if topic.has_accepted_answer }}
     <i class="icon-done"></i>
   {{else}}

--- a/javascripts/list/topic-list-item.hbr
+++ b/javascripts/list/topic-list-item.hbr
@@ -44,11 +44,10 @@
   {{/if}}
 </td>
 
-{{raw "list/solved-column" topic=topic}}
-
 {{#if showPosters}}
   {{raw "list/posters-column" posters=topic.featuredUsers}}
 {{/if}}
+{{raw "list/solved-column" topic=topic}}
 
 {{raw "list/posts-count-column" topic=topic}}
 

--- a/javascripts/list/topic-list-item.hbr
+++ b/javascripts/list/topic-list-item.hbr
@@ -13,7 +13,7 @@
   This causes the topic-post-badge to be considered the same word as "text"
   at the end of the link, preventing it from line wrapping onto its own line.
 --}}
-<td class='main-link clearfix' colspan="1">
+<td class='main-link clearfix' colspan="1" style="border-left:6px solid #{{topic.category.color}}">
   {{~raw-plugin-outlet name="topic-list-before-link"}}
   <span class='link-top-line'>
     {{~raw-plugin-outlet name="topic-list-before-status"}}

--- a/javascripts/list/topic-list-item.hbr
+++ b/javascripts/list/topic-list-item.hbr
@@ -1,0 +1,77 @@
+{{~raw-plugin-outlet name="topic-list-before-columns"}}
+
+{{#if bulkSelectEnabled}}
+  <td class="bulk-select">
+    <input type="checkbox" class="bulk-select">
+  </td>
+{{/if}}
+
+{{!--
+  The `~` syntax strip spaces between the elements, making it produce
+  `<a class=topic-post-badges>Some text</a><span class=topic-post-badges>`,
+  with no space between them.
+  This causes the topic-post-badge to be considered the same word as "text"
+  at the end of the link, preventing it from line wrapping onto its own line.
+--}}
+<td class='main-link clearfix' colspan="1">
+  {{~raw-plugin-outlet name="topic-list-before-link"}}
+  <span class='link-top-line'>
+    {{~raw-plugin-outlet name="topic-list-before-status"}}
+    {{~raw "topic-status" topic=topic}}
+    {{~topic-link topic class="raw-link raw-topic-link"}}
+    {{~#if topic.featured_link}}
+    {{~topic-featured-link topic}}
+    {{~/if}}
+    {{~raw-plugin-outlet name="topic-list-after-title"}}
+    {{~raw "list/unread-indicator" includeUnreadIndicator=includeUnreadIndicator
+                                   topicId=topic.id
+                                   unreadClass=unreadClass~}}
+    {{~#if showTopicPostBadges}}
+    {{~raw "topic-post-badges" unread=topic.unread newPosts=topic.displayNewPosts unseen=topic.unseen url=topic.lastUnreadUrl newDotText=newDotText}}
+    {{~/if}}
+  </span>
+  <div class="link-bottom-line">
+    {{#unless hideCategory}}
+      {{#unless topic.isPinnedUncategorized}}
+        {{category-link topic.category}}
+      {{/unless}}
+    {{/unless}}
+    {{discourse-tags topic mode="list" tagsForUser=tagsForUser}}
+    {{raw "list/action-list" topic=topic postNumbers=topic.liked_post_numbers className="likes" icon="heart"}}
+  </div>
+  {{#if expandPinned}}
+    {{raw "list/topic-excerpt" topic=topic}}
+  {{/if}}
+</td>
+
+{{raw "list/solved-column" topic=topic}}
+
+{{#if showPosters}}
+  {{raw "list/posters-column" posters=topic.featuredUsers}}
+{{/if}}
+
+{{raw "list/posts-count-column" topic=topic}}
+
+{{#if showLikes}}
+  <td class="num likes">
+    {{#if hasLikes}}
+      <a href='{{topic.summaryUrl}}'>
+        {{number topic.like_count}} {{d-icon "heart"}}
+      </a>
+    {{/if}}
+  </td>
+{{/if}}
+
+{{#if showOpLikes}}
+  <td class="num likes">
+    {{#if hasOpLikes}}
+      <a href='{{topic.summaryUrl}}'>
+        {{number topic.op_like_count}} {{d-icon "heart"}}
+      </a>
+    {{/if}}
+  </td>
+{{/if}}
+
+<td class="num views {{topic.viewsHeat}}">{{number topic.views numberKey="views_long"}}</td>
+
+{{raw "list/activity-column" topic=topic class="num" tagName="td"}}

--- a/javascripts/list/topic-list-item.hbr
+++ b/javascripts/list/topic-list-item.hbr
@@ -45,7 +45,6 @@
 </td>
 
 {{raw "list/posts-count-column" topic=topic}}
-
-<td class="num views {{topic.viewsHeat}}">{{number topic.views numberKey="views_long"}}</td>
+{{raw "list/view-count-column" topic=topic class="num" tagName="td"}}
 {{raw "list/activity-column" topic=topic class="num" tagName="td"}}
 {{raw "list/solved-column" topic=topic}}

--- a/javascripts/list/topic-list-item.hbr
+++ b/javascripts/list/topic-list-item.hbr
@@ -44,33 +44,8 @@
   {{/if}}
 </td>
 
-{{#if showPosters}}
-  {{raw "list/posters-column" posters=topic.featuredUsers}}
-{{/if}}
-{{raw "list/solved-column" topic=topic}}
-
 {{raw "list/posts-count-column" topic=topic}}
 
-{{#if showLikes}}
-  <td class="num likes">
-    {{#if hasLikes}}
-      <a href='{{topic.summaryUrl}}'>
-        {{number topic.like_count}} {{d-icon "heart"}}
-      </a>
-    {{/if}}
-  </td>
-{{/if}}
-
-{{#if showOpLikes}}
-  <td class="num likes">
-    {{#if hasOpLikes}}
-      <a href='{{topic.summaryUrl}}'>
-        {{number topic.op_like_count}} {{d-icon "heart"}}
-      </a>
-    {{/if}}
-  </td>
-{{/if}}
-
 <td class="num views {{topic.viewsHeat}}">{{number topic.views numberKey="views_long"}}</td>
-
 {{raw "list/activity-column" topic=topic class="num" tagName="td"}}
+{{raw "list/solved-column" topic=topic}}

--- a/javascripts/list/view-count-column.hbr
+++ b/javascripts/list/view-count-column.hbr
@@ -1,0 +1,1 @@
+<td class="num views {{topic.viewsHeat}}">{{number topic.views numberKey="views_long"}}</td>

--- a/javascripts/list/view-count-column.hbr
+++ b/javascripts/list/view-count-column.hbr
@@ -1,1 +1,1 @@
-<td class="num views {{topic.viewsHeat}}">{{number topic.views numberKey="views_long"}}</td>
+<td class="num views {{topic.viewsHeat}}"><i class="icon-eye"></i>&nbsp;{{number topic.views numberKey="views_long"}}</td>

--- a/javascripts/topic-list-header.hbr
+++ b/javascripts/topic-list-header.hbr
@@ -7,17 +7,8 @@
   </th>
 {{/if}}
 {{raw "topic-list-header-column" order='default' name=listTitle bulkSelectEnabled=bulkSelectEnabled showBulkToggle=toggleInTitle canBulkSelect=canBulkSelect}}
-{{#if showPosters}}
-  {{raw "topic-list-header-column" order='posters' ariaLabel=(i18n "category.sort_options.posters")}}
-{{/if}}
-{{raw "topic-list-header-column" sortable=sortable order='solved' forceName=(theme-i18n "topic_list_item.solved") }}
 {{raw "topic-list-header-column" sortable=sortable number='true' order='posts' name='replies'}}
-{{#if showLikes}}
-  {{raw "topic-list-header-column" sortable=sortable number='true' order='likes' name='likes'}}
-{{/if}}
-{{#if showOpLikes}}
-  {{raw "topic-list-header-column" sortable=sortable number='true' order='op_likes' name='likes'}}
-{{/if}}
 {{raw "topic-list-header-column" sortable=sortable number='true' order='views' name='views'}}
 {{raw "topic-list-header-column" sortable=sortable number='true' order='activity' name='activity'}}
+{{raw "topic-list-header-column" sortable=sortable order='solved' forceName=(theme-i18n "topic_list_item.solved") }}
 {{~raw-plugin-outlet name="topic-list-header-after"~}}

--- a/javascripts/topic-list-header.hbr
+++ b/javascripts/topic-list-header.hbr
@@ -1,0 +1,23 @@
+{{~raw-plugin-outlet name="topic-list-header-before"~}}
+{{#if bulkSelectEnabled}}
+  <th class="bulk-select">
+    {{#if canBulkSelect}}
+      {{raw "flat-button" class="bulk-select" icon="list" title="topics.bulk.toggle"}}
+    {{/if}}
+  </th>
+{{/if}}
+{{raw "topic-list-header-column" order='default' name=listTitle bulkSelectEnabled=bulkSelectEnabled showBulkToggle=toggleInTitle canBulkSelect=canBulkSelect}}
+{{#if showPosters}}
+  {{raw "topic-list-header-column" order='posters' ariaLabel=(i18n "category.sort_options.posters")}}
+{{/if}}
+{{raw "topic-list-header-column" sortable=sortable order='solved' forceName=(theme-i18n "topic_list_item.solved") }}
+{{raw "topic-list-header-column" sortable=sortable number='true' order='posts' name='replies'}}
+{{#if showLikes}}
+  {{raw "topic-list-header-column" sortable=sortable number='true' order='likes' name='likes'}}
+{{/if}}
+{{#if showOpLikes}}
+  {{raw "topic-list-header-column" sortable=sortable number='true' order='op_likes' name='likes'}}
+{{/if}}
+{{raw "topic-list-header-column" sortable=sortable number='true' order='views' name='views'}}
+{{raw "topic-list-header-column" sortable=sortable number='true' order='activity' name='activity'}}
+{{~raw-plugin-outlet name="topic-list-header-after"~}}

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -1,0 +1,3 @@
+fr:
+  topic_list_item:
+    solved: "Résolu"

--- a/scss/common/categories.scss
+++ b/scss/common/categories.scss
@@ -1,0 +1,9 @@
+@import "colors";
+
+.categories-topic-solved {
+    background-color: $verylightgreen;
+}
+
+.topic-list td + .categories-topic-solved {
+  text-align: center;
+}


### PR DESCRIPTION
Personnalisation des listes des écrans tops, récents et des différentes catégories, pour coller au style de la page d’accueil.
(inclut également https://github.com/betagouv/itou-theme-discourse/pull/8/commits/0751718959a738db49cb69a5d712d6139a3bdcd9 car dommage de faire une PR rien que pour ça).

Comme d’hab on navigue serré, mais cette fois-ci ça a abouti à un résultat utilisable ;)

![Capture d’écran de 2021-02-23 17-31-59](https://user-images.githubusercontent.com/1223316/108875244-403f5480-75fd-11eb-85d6-1b661faaea39.png)
