### PR TITLE
Fixed activity column width & colors in categories

### DIFF
--- a/javascripts/list/activity-column.hbr
+++ b/javascripts/list/activity-column.hbr
@@ -1,6 +1,5 @@
 <{{tagName}} class="{{class}} {{cold-age-class topic.createdAt startDate=topic.bumpedAt class=""}} activity" title="{{html-safe topic.bumpedAtTitle}}">
   <a class="post-activity" href="{{topic.lastPostUrl}}">
-    {{~raw-plugin-outlet name="topic-list-before-relative-date"~}}
-    <i class="icon-calendar"></i>&nbsp;{{~format-date topic.bumpedAt format="tiny" noTitle="true"~}}
+    {{~raw-plugin-outlet name="topic-list-before-relative-date"~}} <i class="icon-calendar"></i>&nbsp;{{~format-date topic.bumpedAt format="tiny" noTitle="true"~}}
   </a>
 </{{tagName}}>

--- a/javascripts/list/topic-list-item.hbr
+++ b/javascripts/list/topic-list-item.hbr
@@ -46,5 +46,5 @@
 
 {{raw "list/posts-count-column" topic=topic}}
 {{raw "list/view-count-column" topic=topic class="num" tagName="td"}}
-{{raw "list/activity-column" topic=topic class="num" tagName="td"}}
+{{raw "list/activity-column" topic=topic class="num activity" tagName="td"}}
 {{raw "list/solved-column" topic=topic}}

--- a/scss/common/categories.scss
+++ b/scss/common/categories.scss
@@ -12,3 +12,11 @@
 .topic-list td + .categories-topic-solved {
   text-align: center;
 }
+
+.topic-list td + .posts, .topic-list td + .activity, .topic-list td + .views, .posts .number {
+  color: $black;
+}
+
+.topic-list .activity {
+  width: 90px;
+}


### PR DESCRIPTION
Suite aux retours, voici les corrections sur l’affichage de la liste coté catégories (même couleurs pour les dernières colonnes que sur la home, et pas de retours à la ligne).

![Capture d’écran de 2021-03-12 10-31-30](https://user-images.githubusercontent.com/1223316/110920953-454f1400-831e-11eb-9ec6-c9e8116611b0.png)
