### PR TITLE
Modification des écrans ressourcerie

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ If you are getting started making a discourse theme, I’ve found these links to
  - [How to add custom content that only appears on your homepage](https://meta.discourse.org/t/how-to-add-custom-content-that-only-appears-on-your-homepage/131415)
  - [Splitting up theme SCSS into multiple files](https://meta.discourse.org/t/splitting-up-theme-scss-into-multiple-files/115126)
  - [Splitting up theme Javascript into multiple files](https://meta.discourse.org/t/splitting-up-theme-javascript-into-multiple-files/119369)
+ - On customizing specific categories: [A](https://meta.discourse.org/t/adding-custom-css-on-particular-categories/140954) and [B](https://meta.discourse.org/t/modify-new-topic-editor-grey-guide-text-copy-per-category/128920/3). (I mostly want to ensure something is clear: I’m innocent, they made me do it.)
+
 
 ## Contributing
 

--- a/common/common.scss
+++ b/common/common.scss
@@ -11,3 +11,4 @@
 @import "common/cleanups";
 @import "common/post-menu";
 @import "common/categories";
+@import "common/ressourcerie";

--- a/javascripts/itou/initializers/customize-ressourcerie.js.es6
+++ b/javascripts/itou/initializers/customize-ressourcerie.js.es6
@@ -1,0 +1,19 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+export default {
+  name: "customize-ressourcerie",
+  initialize(){
+    withPluginApi("0.8.7", api => {
+        let ressourcerie_category_pattern = /c\/ressourerie/;
+
+        api.onPageChange((url, title) => {
+          if(url.match(ressourcerie_category_pattern)) {
+            $("#create-topic .d-button-label").text("Partager une ressource");
+            // note: this does NOT work if we directly refresh said category and open the composer, because the composers text takes precedence
+            // this does work if we browse in the category then open the composer
+            $(".composer-action-title .action-title").text("Partager une ressource");
+          }
+        });
+
+    });
+  }
+}

--- a/javascripts/itou/initializers/customize-ressourcerie.js.es6
+++ b/javascripts/itou/initializers/customize-ressourcerie.js.es6
@@ -1,19 +1,27 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
+
+function initializeRessourcerieOverrides(api) {
+  let ressourcerie_category_pattern = /c\/ressourcerie/;
+
+  api.onPageChange((url, title) => {
+    if(url.match(ressourcerie_category_pattern)) {
+      $("#create-topic .d-button-label").text("Partager une ressource");
+      // note: this does NOT work if we directly refresh said category and open the composer, because the composers text takes precedence
+      // this does work though if we browse in the category then open the composer
+      $(".composer-action-title .action-title").text("Partager une ressource");
+    }
+  });
+
+  api.onToolbarCreate(toolbar => {
+    if(window.location.href.match(ressourcerie_category_pattern)) {
+      $(".composer-action-title .action-title").text("Partager une ressource");
+    }
+  });
+}
+
 export default {
   name: "customize-ressourcerie",
   initialize(){
-    withPluginApi("0.8.7", api => {
-        let ressourcerie_category_pattern = /c\/ressourerie/;
-
-        api.onPageChange((url, title) => {
-          if(url.match(ressourcerie_category_pattern)) {
-            $("#create-topic .d-button-label").text("Partager une ressource");
-            // note: this does NOT work if we directly refresh said category and open the composer, because the composers text takes precedence
-            // this does work if we browse in the category then open the composer
-            $(".composer-action-title .action-title").text("Partager une ressource");
-          }
-        });
-
-    });
+    withPluginApi("0.8.7", api => initializeRessourcerieOverrides(api));
   }
 }

--- a/scss/common/ressourcerie.scss
+++ b/scss/common/ressourcerie.scss
@@ -1,3 +1,5 @@
+@import "colors";
+
 div.d-editor-container div.d-editor-button-bar  {
   button.link.btn.no-text.btn-icon:after {
     content: "Ajouter un lien";
@@ -9,6 +11,13 @@ div.d-editor-container div.d-editor-button-bar  {
 
 .save-or-cancel {
   .btn.btn-icon-text.btn-primary.create {
-    color: red !important;
+    border-radius: 5px;
+
+    height: 41px;
+    font-weight: bolder;
+
+    border: 1px solid $darkgreen;
+    background-color: $darkgreen;
+    color: $white;
   }
 }

--- a/scss/common/ressourcerie.scss
+++ b/scss/common/ressourcerie.scss
@@ -1,0 +1,14 @@
+div.d-editor-container div.d-editor-button-bar  {
+  button.link.btn.no-text.btn-icon:after {
+    content: "Ajouter un lien";
+  }
+  button.upload.btn.no-text.btn-icon:after {
+    content: "Importer un document";
+  }
+}
+
+.save-or-cancel {
+  .btn.btn-icon-text.btn-primary.create {
+    color: red !important;
+  }
+}


### PR DESCRIPTION
Quelques éléments de design spécifiques aux écrans de la ressourcerie

# notes sur les galères:

J’ai eu beaucoup de mal à me brancher sur les évènements du `composer`, l’éditeur de message, pour par exemple changer le titre quand on est sur la ressourcerie. Quelques trucs qui ne fonctionnent pas, comme dirait [Edison](https://due.com/blog/thomas-edison-10000-ways-that-wont-work/):

 - pas de doc sur l’API des plugins discourse au dela d’un hello world.
 - pas (ok, peu) d’exemple concret dans le code
 - un forum officiel qui s’étonne [de manière répétée](https://meta.discourse.org/t/plugin-api-documentations/67988/4) d’une telle demande. Bah quoi, tu sais pas lire le code d’un projet qui fait 250k lignes de javascript… tu serais pas un peu nul?
 - des articles sur des exemples tangents obsolètes ([lui](https://meta.discourse.org/t/solved-in-plugin-opening-the-composer-without-changing-the-route/67710) ou [lui](https://meta.discourse.org/t/javascript-hook-for-composer/137967/3))
 - pas de liste d’évènement sur laquelle me greffer
 - des [exemples buggés](https://meta.discourse.org/t/what-is-the-proper-function-to-initalize-stuff-on-composer-open/143142) chez les quelques aventuriers qui ont tenté l’aventure malgré tout

Dans l’idée on veut sans doute un truc de ce genre, j’ai testé un paquet de variantes sans arriver à un truc 100% satisfaisant

```js
api.modifyClass('controller:composer', {
  actions: {
    open(options) {
      this._super(options);
      // notre changement de titre si on est dans la bonne catégorie
    }
  }
});
```

la solution que j’ai trouvé a été d’utiliser un autre évènement (la création de la toolbar du composer)