### PR TITLE
Ajout de la colonne 'utilisateur' dans les listes

### DIFF
--- a/javascripts/list/topic-list-item.hbr
+++ b/javascripts/list/topic-list-item.hbr
@@ -44,6 +44,9 @@
   {{/if}}
 </td>
 
+{{#if showPosters}}
+  {{raw "list/posters-column" posters=topic.featuredUsers}}
+{{/if}}
 {{raw "list/posts-count-column" topic=topic}}
 {{raw "list/view-count-column" topic=topic class="num" tagName="td"}}
 {{raw "list/activity-column" topic=topic class="num activity" tagName="td"}}

--- a/javascripts/topic-list-header.hbr
+++ b/javascripts/topic-list-header.hbr
@@ -7,6 +7,9 @@
   </th>
 {{/if}}
 {{raw "topic-list-header-column" order='default' name=listTitle bulkSelectEnabled=bulkSelectEnabled showBulkToggle=toggleInTitle canBulkSelect=canBulkSelect}}
+{{#if showPosters}}
+  {{raw "topic-list-header-column" order='posters' ariaLabel=(i18n "category.sort_options.posters")}}
+{{/if}}
 {{raw "topic-list-header-column" sortable=sortable number='true' order='posts' name='replies'}}
 {{raw "topic-list-header-column" sortable=sortable number='true' order='views' name='views'}}
 {{raw "topic-list-header-column" sortable=sortable number='true' order='activity' name='activity'}}


### PR DESCRIPTION
Nous l’avions supprimé, mais on se rend compte que ça manque, donc cette colonne revient