### PR TITLE
Personnalisation du logo

### DIFF
--- a/scss/common/header.scss
+++ b/scss/common/header.scss
@@ -5,15 +5,8 @@
     height: 114px;
     box-shadow: none;
     .title img {
-      width: 114px;
-      height: 114px;
-    }
-    .title::after {
-      content: "Le forum de l’inclusion";
-      font-family: Helvetica, Arial, sans-serif;
-      font-size: 1.25rem;
-      font-weight: bold;
-      line-height: 1.5;
+      width: 298px;
+      height: 102px;
     }
   }
   .extra-info-wrapper {


### PR DESCRIPTION
Seconde partie de https://github.com/betagouv/itou-theme-discourse/pull/9: on préfère utiliser un logo tel que prévu (plutôt qu’un texte avec une font custom, ou logo pour le ministère + texte).

Le logo est importé via l’admin, mais il reste nécessaire de spécifier des dimensions sur mesure pour que le logo soit rendu correctement.